### PR TITLE
Fix issue with mail generation (#67)

### DIFF
--- a/emails-and-notifications/sendgrid-email/email.js
+++ b/emails-and-notifications/sendgrid-email/email.js
@@ -20,7 +20,7 @@ const generateRequest = mail => sendgrid.emptyRequest({
 })
 
 module.exports = event => new Promise((resolve, reject) => sendgrid.API(
-  generateRequest(generateMail(data)(event.data[model].node)), 
+  generateRequest(generateMail(event.data[model].node)), 
   (error, response) => {
     if (error) {
       console.log(error)


### PR DESCRIPTION
Change the way to call the email generation from `generateMail(data)(event.data[model].node)` into `generateMail(event.data[model].node)`, probably due to a mistake when doing some kind of refactoring to remove the `data` variable